### PR TITLE
Allow more than 50 channels to work with CLI

### DIFF
--- a/react-starter-sites/bin/serverUtils.js
+++ b/react-starter-sites/bin/serverUtils.js
@@ -225,7 +225,7 @@ module.exports.getChannelsFromServer = function (server) {
 			user: server.username,
 			password: server.password
 		});
-		var url = server.url + '/content/management/api/v1.1/channels';
+		var url = server.url + '/content/management/api/v1.1/channels?limit=1000';
 		client.get(url, function (data, response) {
 			if (response && response.statusCode === 200 && data) {
 				var channels = [];


### PR DESCRIPTION
Work around limit of 50 responses to number of channels from the GET /content/management/api/v1.1/channels call to the management API. This can be reverted once that API truly returns all channels.