### PR TITLE
Updated install instructions for Mac

### DIFF
--- a/sites/README.MD
+++ b/sites/README.MD
@@ -30,7 +30,8 @@ npm install
 > **Mac**:
 
 ```
-sudo ln -s $PWD/content-and-experience-toolkit/sites/node_modules/.bin/cec /usr/local/bin/cec
+npm pack
+npm install cec-sites-toolkit-<version>.tgz --global
 ```
 
 > **Windows**:


### PR DESCRIPTION
The npm pack and npm install instructions are in line with npm instructions. Now the  globally installed package is versioned.
Somehow npm link did not work, as that would be comparable to the softlink instructions that are currently in the README. 