### PR TITLE
Add cec control-content share -o 'viewer'

### DIFF
--- a/sites/bin/asset.js
+++ b/sites/bin/asset.js
@@ -3340,6 +3340,7 @@ var _updateCollectionPermission = function (server, repository, collections, use
 							server: server,
 							id: collection.id,
 							repositoryId: repository.id,
+							viewAllCollectionsEnabled: repository.viewAllCollectionsEnabled,
 							type: 'collection'
 						}));
 				});

--- a/sites/bin/cec/cec.js
+++ b/sites/bin/cec/cec.js
@@ -226,7 +226,7 @@ var getResourceRoles = function () {
 };
 
 var getCollectionRoles = function () {
-	const roles = ['manager', 'contributor'];
+	const roles = ['manager', 'contributor', 'viewer'];
 	return roles;
 };
 

--- a/sites/test/server/serverRest.js
+++ b/sites/test/server/serverRest.js
@@ -4878,12 +4878,12 @@ module.exports.getCategoryProperties = function (args) {
 	});
 };
 
-var _getResourcePermissions = function (server, id, type, repositoryId) {
+var _getResourcePermissions = function (server, id, type, repositoryId, viewAllCollectionsEnabled=false) {
 	return new Promise(function (resolve, reject) {
 		var resourceType = type === 'repository' ? 'repositories' : (type + 's');
 		var url;
 		if (type === 'collection') {
-			url = server.url + '/content/management/api/v1.1/repositories/' + repositoryId + '/collections/' + id + '/permissions';
+			url = server.url + '/content/management/api/v1.1/repositories/' + repositoryId + '/collections/' + id + '/permissions?isCollectionOnly=' + !viewAllCollectionsEnabled;
 		} else {
 			url = server.url + '/content/management/api/v1.1/' + resourceType + '/' + id + '/permissions';
 		}
@@ -4938,7 +4938,7 @@ var _getResourcePermissions = function (server, id, type, repositoryId) {
  * @returns {Promise.<object>} The data object returned by the server.
  */
 module.exports.getResourcePermissions = function (args) {
-	return _getResourcePermissions(args.server, args.id, args.type, args.repositoryId);
+	return _getResourcePermissions(args.server, args.id, args.type, args.repositoryId, args.viewAllCollectionsEnabled);
 };
 
 


### PR DESCRIPTION
This also needs a server-side change to allow adding viewer as a role via the API. Currently, you'll get a message back from the API stating
```
- group {GROUP NAME} already granted with role viewer on collection {COLLECTION NAME}
```